### PR TITLE
Breaking text for very small displays

### DIFF
--- a/public/css/indexStyle.css
+++ b/public/css/indexStyle.css
@@ -35,3 +35,7 @@
   margin-bottom: 20px;
   margin-top: 20px;
 }
+
+#editor-name-header {
+  word-wrap: break-word;
+}

--- a/views/index.pug
+++ b/views/index.pug
@@ -7,7 +7,7 @@ block content
   .container
     br
     br
-    h1.header.center(class=sectext) Resolution Editor
+    h1.header.center#editor-name-header(class=sectext) Resolution Editor
     .center: h5.header.light A
       em  simple
       |  way of creating and editing resolutions without having to have to deal with formatting.


### PR DESCRIPTION
I can imagine some person will come along and try to use the editor on their tiny phone and then complain about all the input fields being too small because currently the headers don't break inside words and make the UI squish to the left side. Do you think this is helpful or necessary? (We can apply in-word braking to more text if it is.)
No not merge before discussion.