### PR TITLE
Disable mobile tooltips

### DIFF
--- a/public/js/indexInit.js
+++ b/public/js/indexInit.js
@@ -415,6 +415,11 @@ $.fn.addClause = function(amount, activationStateChanges) {
   return this;
 };
 
+//register touch event and remove tooltips for touch-devices
+$("body").on("touchstart", function() {
+  $(".tooltipped").tooltip("remove");
+  $(this).addClass("blue");
+});
 
 //do things when the document has finished loading
 $(document).ready(function() {

--- a/public/js/indexInit.js
+++ b/public/js/indexInit.js
@@ -418,7 +418,6 @@ $.fn.addClause = function(amount, activationStateChanges) {
 //register touch event and remove tooltips for touch-devices
 $("body").on("touchstart", function() {
   $(".tooltipped").tooltip("remove");
-  $(this).addClass("blue");
 });
 
 //do things when the document has finished loading


### PR DESCRIPTION
Makes devices that fire `touchstart` not display any tooltips because they'll just get in the way. Fixes a little bit #42 